### PR TITLE
Add awesome_print dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'http://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'awesome_print', require: false
   gem 'grape', '>= 0.19.1'
   gem 'pry', platforms: [:mri]
   gem 'pry-byebug', platforms: [:mri]

--- a/grape-starter.gemspec
+++ b/grape-starter.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gli', '~> 2.16'
   spec.add_dependency 'activesupport', '~> 5.0'
   spec.add_dependency 'rubocop', '~> 0.48'
+  spec.add_dependency 'awesome_print', '~> 1.7'
 end

--- a/lib/starter/version.rb
+++ b/lib/starter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Starter
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
Fixes grape-starter executable crash.

Addresses Issue #6