### PR TITLE
Add base configuration for ActiveRecord, untested yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ with following options:
 ```
 -f, --force                # overwrites existend project
 -p foobar, --prefix=foobar # provide a prefix under which the API can be accessed, default: api
--o sequel, --orm=sequel    # create also needed files and folders for the specified ORM
+-o sequel, --orm=sequel    # create files for the specified ORM, default: sequel, available: activerecord
 ```
 
 This command creates a folder named `awesome_api` containing the skeleton. With following structure:

--- a/bin/grape-starter
+++ b/bin/grape-starter
@@ -27,7 +27,7 @@ command :new do |c|
          desc: 'sets the prefix of the API'
   c.flag [:o, :orm],
          default_value: 'sequel',
-         desc: 'prepares for the given ORM (Sequel, …)'
+         desc: 'prepares for the given ORM (Sequel, ActiveRecord)'
 
   c.action do |global_options, options, args|
     dest = args.empty? ? nil : File.join(Dir.getwd, args.first)

--- a/lib/starter/builder/names.rb
+++ b/lib/starter/builder/names.rb
@@ -13,6 +13,10 @@ module Starter
         require 'starter/builder/templates/sequel'
         extend(::Starter::Templates::Sequel)
         "#{klass_name} < #{model_klass}"
+      when 'activerecord'
+        require 'starter/builder/templates/activerecord'
+        extend(::Starter::Templates::ActiveRecord)
+        "#{klass_name} < #{model_klass}"
       else
         klass_name
       end

--- a/lib/starter/builder/orms.rb
+++ b/lib/starter/builder/orms.rb
@@ -8,6 +8,11 @@ module Starter
         when 'sequel'
           require 'starter/builder/templates/sequel'
           extend(::Starter::Templates::Sequel)
+        when 'activerecord'
+          require 'starter/builder/templates/activerecord'
+          extend(::Starter::Templates::ActiveRecord)
+          # Fixes pooling
+          add_middleware(dest, 'ActiveRecord::Rack::ConnectionManagement')
         else
           return
         end
@@ -29,6 +34,12 @@ module Starter
 
       def build_config(dest)
         FileFoo.write_file(File.join(dest, 'database.yml'), config)
+      end
+
+      # adds a middleware to config.ru
+      def add_middleware(dest, middleware)
+        replacement = "use #{middleware}\n\n\\1"
+        FileFoo.call!(File.join(dest, 'config.ru')) { |content| content.sub!(/^(run.+)$/, replacement) }
       end
 
       def append_to_file(file_name, content)

--- a/lib/starter/builder/templates/activerecord.rb
+++ b/lib/starter/builder/templates/activerecord.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Starter
+  module Templates
+    module ActiveRecord
+      def model_klass
+        'ActiveRecord::Base'
+      end
+
+      def initializer
+        <<-FILE.strip_heredoc
+        require 'yaml'
+        require 'erb'
+        require 'active_record'
+
+        config_content = File.read(File.join('config', 'database.yml'))
+
+        db_conf = YAML.safe_load(ERB.new(config_content).result)
+        env = ENV['RACK_ENV'] || 'development'
+
+        ActiveRecord::Base.establish_connection db_conf[env]
+        logger = if %w[development test].include? env
+          log_dir = File.join(Dir.getwd, 'log')
+          log_file = File.join(log_dir, 'db.log')
+          FileUtils.mkdir(log_dir) unless Dir.exist?(log_dir)
+          Logger.new(File.open(log_file, 'a'))
+        else
+          Logger.new(STDOUT)
+        end
+
+        ActiveRecord::Base.logger = logger
+
+        # Middleware
+        module ActiveRecord
+          module Rack
+            # ActiveRecord >= 5 removes the Pool management
+            class ConnectionManagement
+              def initialize(app)
+                @app = app
+              end
+
+              def call(env)
+                response = @app.call(env)
+                response[2] = ::Rack::BodyProxy.new(response[2]) do
+                  ActiveRecord::Base.clear_active_connections!
+                end
+
+                return response
+              rescue Exception
+                ActiveRecord::Base.clear_active_connections!
+                raise
+              end
+            end
+          end
+        end
+        FILE
+      end
+
+      def config # TODO: Dry (Same config for Sequel)
+        <<-FILE.strip_heredoc
+        # ActiveRecord Database Configuration
+        development:
+          adapter: 'sqlite3'
+          host: localhost
+          port: 27017
+          database: "db/development.sqlite3"
+          username:
+          password:
+
+        test:
+          adapter: 'sqlite3'
+          host: localhost
+          port: 27017
+          database: "db/test.sqlite3"
+          username:
+          password:
+
+        production:
+          adapter: 'sqlite3'
+          host: localhost
+          port: 27017
+          database: "db/production.sqlite3"
+          username:
+          password:
+        FILE
+      end
+
+      def rakefile
+        <<-FILE.strip_heredoc
+        # ActiveRecord DB tasks
+
+        task :load_config do
+          config_dir = File.expand_path('../config', __FILE__)
+          config_content = File.read(File.join(config_dir, 'database.yml'))
+
+          DatabaseTasks.env = ENV['RACK_ENV'] || 'development'
+          DatabaseTasks.db_dir = db_dir
+          config = YAML.safe_load(ERB.new(config_content).result)
+          DatabaseTasks.database_configuration = config
+          DatabaseTasks.migrations_paths = File.join(db_dir, 'migrate')
+
+          ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
+          ActiveRecord::Base.establish_connection DatabaseTasks.env.to_sym
+        end
+
+        # Loads AR tasks like db:create, db:drop etc..
+        load 'active_record/railties/databases.rake'
+        FILE
+      end
+
+      def gemfile
+        <<-FILE.strip_heredoc
+        # DB stack
+        gem 'activerecord', '~> 5.1'
+        gem 'sqlite3'
+        FILE
+      end
+    end
+  end
+end

--- a/lib/starter/version.rb
+++ b/lib/starter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Starter
-  VERSION = '0.7.0-sequel'
+  VERSION = '0.7.0'
 end

--- a/template/config.ru
+++ b/template/config.ru
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 
 require 'rack/cors'
+require_relative 'config/application'
 
 use Rack::CommonLogger
 
@@ -10,7 +11,5 @@ use Rack::Cors do
     resource '*', headers: :any, methods: %i[get post put patch delete options]
   end
 end
-
-require File.expand_path('../config/application', __FILE__)
 
 run App.new


### PR DESCRIPTION
Adds ActiveRecord support.

Some things are missing still:

We should add this middleware to ensure the connection management is well done
```ruby
module ActiveRecord
  module Rack
    # ActiveRecord >= 5 removes the Pool management
    class ConnectionManagement
      def initialize(app)
        @app = app
      end

      def call(env)
        response = @app.call(env)
        response[2] = ::Rack::BodyProxy.new(response[2]) do
          ActiveRecord::Base.clear_active_connections!
        end

        return response
      rescue Exception
        ActiveRecord::Base.clear_active_connections!
        raise
      end
    end
  end
end
```

Maybe we could add a `common.rb` for databases.yml of ORMs, just overriding variables like `@dbname`, `@username` etc.. to generates the same config file with custom fields.