### PR TITLE
fix script/server shebang for ubuntu

### DIFF
--- a/template/script/server
+++ b/template/script/server
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -l
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Generated 'script/server' does not start on ubuntu linux
```
$ ./script/server
/usr/bin/env: ‘bash -l’: No such file or directory
```
Removing option '-l' from shebang seems to fix the problem.