### PR TITLE
Enable ActiveRecord 6.0

### DIFF
--- a/grape-starter.gemspec
+++ b/grape-starter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'gli', '~> 2.18'
-  spec.add_dependency 'activesupport', '~> 5'
+  spec.add_dependency 'activesupport', '>= 5.0.0', '< 7.0'
   spec.add_dependency 'rubocop', '~> 0.65'
   spec.add_dependency 'awesome_print', '~> 1.7'
 end


### PR DESCRIPTION
Relax activesupport version dependency in order to allow apps to use ActiveRecord 6.0.0 gem.