### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:3
 ENV NODE_ENV='development'
 ENV RACK_ENV='development'
 
-ADD . /dummy
+COPY . /dummy
 WORKDIR /dummy
 
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance